### PR TITLE
Add Ability to Use HTTP-POST Binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 # Simple, secure SAML service provider
 
-This library provides with a simple and secure SAML service provider.  
-At the moment it supports only service provider initiated login (using redirect binding) but more will come.
+This library provides with a simple and secure SAML service provider.
 
 ## Options
 
@@ -44,8 +43,11 @@ It is recommended that you use the metadata file as it's easier to maintain than
 A globally unique identifier that identifies the identity provider. This corresponds to the entityId saml field.
 Same restrictions as for the sp id apply.
 
-`idp.loginUrl`  
-The url that we should send auth requests to
+`idp.loginRedirectUrl`  
+The url that we should send auth requests using the HTTP-Redirect binding to
+
+`idp.loginPostUrl`  
+The url that we should send auth requests using the HTTP-POST binding to
 
 `idp.signature`  
 This is the object that contains the certificates and signature algorithm that we should accept for signing the
@@ -124,7 +126,8 @@ const options = {
     },
     idp: {
         id: 'test-idp',
-        loginUrl: 'http://localhost:7000/idp/requestLogin',
+        loginRedirectUrl: 'http://localhost:7000/idp/requestLogin',
+        loginPostUrl: 'http://localhost:7000/idp/requestLogin',
         signature: {
             algorithm: <'sha256'>'sha256',
             allowedCertificates: []

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zaptic-external/saml",
-    "version": "2.0.8",
+    "version": "3.0.0",
     "description": "Minimal saml service provider with support for sp-initiated redirect login only",
     "main": "dist/service-provider.js",
     "types": "dist/service-provider.d.ts",

--- a/src/helpers/encoding.ts
+++ b/src/helpers/encoding.ts
@@ -2,7 +2,7 @@ import * as zlib from 'zlib'
 import * as querystring from 'querystring'
 
 export function decodePostResponse(message: string) {
-    return new Buffer(message, 'base64').toString('utf8')
+    return Buffer.from(message, 'base64').toString('utf8')
 }
 
 // See https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf 3.4.4.1 DEFLATE Encoding
@@ -10,7 +10,7 @@ export function decodePostResponse(message: string) {
 // NB: querystring does the uri encoding
 export function encodeRedirectParameters(xml: string, RelayState?: string) {
     return new Promise((resolve, reject) => {
-        zlib.deflateRaw(new Buffer(xml), (error, deflatedMessage) => {
+        zlib.deflateRaw(Buffer.from(xml), (error, deflatedMessage) => {
             if (error) return reject(error)
 
             const SAMLRequest = deflatedMessage.toString('base64')

--- a/src/helpers/encoding.ts
+++ b/src/helpers/encoding.ts
@@ -29,5 +29,5 @@ export function encodeRedirectParameters(xml: string, RelayState?: string) {
 //     The consumer should insert the data into html form fields and submit.
 export function encodePostFormFields(xml: string, RelayState?: string) {
     const SAMLRequest = Buffer.from(xml).toString('base64')
-    return RelayState ? { SAMLRequest, RelayState } : { SAMLRequest }
+    return { SAMLRequest, RelayState }
 }

--- a/src/helpers/encoding.ts
+++ b/src/helpers/encoding.ts
@@ -22,3 +22,12 @@ export function encodeRedirectParameters(xml: string, RelayState?: string) {
         })
     })
 }
+
+// See https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf 3.5.4 Message Encoding
+// TLDR: xml -> base64 -> application/x-www-form-urlencoded
+// NB: This does not handle the final step of form encoding.
+//     The consumer should insert the data into html form fields and submit.
+export function encodePostFormFields(xml: string, RelayState?: string) {
+    const SAMLRequest = Buffer.from(xml).toString('base64')
+    return RelayState ? { SAMLRequest, RelayState } : { SAMLRequest }
+}

--- a/src/helpers/encoding.ts
+++ b/src/helpers/encoding.ts
@@ -5,9 +5,11 @@ export function decodePostResponse(message: string) {
     return Buffer.from(message, 'base64').toString('utf8')
 }
 
-// See https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf 3.4.4.1 DEFLATE Encoding
-// TLDR: xml -> deflate -> base64 -> encodeURI
-// NB: querystring does the uri encoding
+/**
+ * See https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf 3.4.4.1 DEFLATE Encoding
+ * TLDR: xml -> deflate -> base64 -> encodeURI
+ * NB: querystring does the uri encoding
+ */
 export function encodeRedirectParameters(xml: string, RelayState?: string) {
     return new Promise((resolve, reject) => {
         zlib.deflateRaw(Buffer.from(xml), (error, deflatedMessage) => {
@@ -22,11 +24,12 @@ export function encodeRedirectParameters(xml: string, RelayState?: string) {
         })
     })
 }
-
-// See https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf 3.5.4 Message Encoding
-// TLDR: xml -> base64 -> application/x-www-form-urlencoded
-// NB: This does not handle the final step of form encoding.
-//     The consumer should insert the data into html form fields and submit.
+/**
+ * See https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf 3.5.4 Message Encoding
+ * TLDR: xml -> base64 -> application/x-www-form-urlencoded
+ * NB: This does not handle the final step of form encoding.
+ *     The consumer should insert the data into html form fields and submit.
+ */
 export function encodePostFormFields(xml: string, RelayState?: string) {
     const SAMLRequest = Buffer.from(xml).toString('base64')
     return { SAMLRequest, RelayState }

--- a/src/service-provider.ts
+++ b/src/service-provider.ts
@@ -50,6 +50,17 @@ export interface OptionsWithMetadata {
     sp: SPOptions
 }
 
+/*
+ * Data to be inserted into a hidden form and auto-submitted to use the HTTP-POST binding.
+ */
+export interface LoginRequestPostFormData {
+    action: string
+    fields: {
+        SAMLRequest: string
+        RelayState?: string
+    }
+}
+
 interface SAMLProviderOptions {
     XSDs: {
         protocol: Validator
@@ -142,7 +153,7 @@ export default class SAMLProvider {
     public async buildLoginRequestPostFormData(
         relayState?: string,
         forceAuthentication = this.preferences.forceAuthenticationByDefault
-    ) {
+    ): Promise<LoginRequestPostFormData> {
         const xml = await this.buildLoginRequestXML(forceAuthentication)
 
         return { action: this.identityProvider.postLoginUrl, fields: encodePostFormFields(xml, relayState) }

--- a/src/service-provider.ts
+++ b/src/service-provider.ts
@@ -50,7 +50,7 @@ export interface OptionsWithMetadata {
     sp: SPOptions
 }
 
-/*
+/**
  * Data to be inserted into a hidden form and auto-submitted to use the HTTP-POST binding.
  */
 export interface LoginRequestPostFormData {

--- a/src/service-provider.ts
+++ b/src/service-provider.ts
@@ -10,7 +10,8 @@ import { Certificate, getNonExpired } from './helpers/certificate'
 
 export interface IDPOptions {
     id: string
-    loginUrl: string
+    redirectLoginUrl: string
+    postLoginUrl: string
     signature: {
         algorithm: 'sha256' | 'sha512'
         allowedCertificates: string[]
@@ -115,7 +116,7 @@ export default class SAMLProvider {
         const request = getLoginXML(await this.getUUID(), {
             serviceProviderId: this.serviceProvider.id,
             assertionUrl: this.serviceProvider.assertionUrl,
-            loginUrl: this.identityProvider.loginUrl,
+            loginUrl: this.identityProvider.redirectLoginUrl,
             forceAuthentication,
             addNameIdPolicy: this.preferences.addNameIdPolicy
         })
@@ -125,11 +126,11 @@ export default class SAMLProvider {
 
         // Google uses SingleSignOnService URLs that have a query param set in them so we need to detect that and build
         // the url accordingly
-        if (url.parse(this.identityProvider.loginUrl).query) {
-            return this.identityProvider.loginUrl + '&' + (await encodeRedirectParameters(xml, relayState))
+        if (url.parse(this.identityProvider.redirectLoginUrl).query) {
+            return this.identityProvider.redirectLoginUrl + '&' + (await encodeRedirectParameters(xml, relayState))
         }
 
-        return this.identityProvider.loginUrl + '?' + (await encodeRedirectParameters(xml, relayState))
+        return this.identityProvider.redirectLoginUrl + '?' + (await encodeRedirectParameters(xml, relayState))
     }
 
     public async parseLoginResponse<T extends { [key: string]: string }>(query: {

--- a/src/spec/metadata.ts
+++ b/src/spec/metadata.ts
@@ -15,7 +15,8 @@ describe('Metadata.extract', function() {
                     algorithm: 'sha256',
                     allowedCertificates: ['SignCert31', 'SignCert32', 'SignCert33']
                 },
-                loginUrl: 'https://login.microsoftonline.com/id/saml2'
+                redirectLoginUrl: 'https://login.microsoftonline.com/id/saml2',
+                postLoginUrl: 'https://login.microsoftonline.com/id/saml2'
             }
         }
 
@@ -36,6 +37,17 @@ describe('Metadata.extract', function() {
             ''
         )
         const expectedError = 'No login url found for the HTTP-Redirect binding'
+
+        await assertPromiseRejects(extract(xml), expectedError)
+    })
+
+    it('should throw an error if there are not login urls for the HTTP-POST Binding', async function() {
+        const xml = getMetadata().replace(
+            '<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" ' +
+                'Location="https://login.microsoftonline.com/id/saml2" />',
+            ''
+        )
+        const expectedError = 'No login url found for the HTTP-POST binding'
 
         await assertPromiseRejects(extract(xml), expectedError)
     })

--- a/src/spec/service-provider.ts
+++ b/src/spec/service-provider.ts
@@ -43,7 +43,18 @@ describe('SAMLProvider', function() {
         getUUID: () => 'test-uuid'
     }
 
-    function checkRedirectURL(redirectURL: string, relayState: string, validator: Validator) {
+    function checkSamlRequest(samlRequest: string, signed: boolean, validator: Validator) {
+        // Ths is naive but should be enough for now
+        if (signed) {
+            assert.include(samlRequest, 'Signature', 'Request should be signed')
+        } else {
+            assert.notInclude(samlRequest, 'Signature', 'Request should not signed')
+        }
+
+        return validator(samlRequest)
+    }
+
+    function checkRedirectURL(redirectURL: string, relayState: string, signed: boolean, validator: Validator) {
         const parts = redirectURL.split('?')
         assert.equal(parts[0], options.idp.redirectLoginUrl, 'Login url must be the one provided in the options')
 
@@ -54,10 +65,15 @@ describe('SAMLProvider', function() {
 
         const request = zlib.inflateRawSync(new Buffer(<string>SAMLRequest, 'base64')).toString('utf8')
 
-        // Ths is naive but should be enough for now
-        assert.include(request, 'Signature', 'Request should be signed')
+        return checkSamlRequest(request, signed, validator)
+    }
 
-        return validator(request)
+    function checkPostFormData(data: any, relayState: string, signed: boolean, validator: Validator) {
+        assert.equal(data.action, options.idp.redirectLoginUrl)
+        assert.equal(data.fields.RelayState, relayState)
+
+        const request = Buffer.from(data.fields.SAMLRequest, 'base64').toString()
+        return checkSamlRequest(request, signed, validator)
     }
 
     it('should generate valid metadata', async function() {
@@ -73,8 +89,10 @@ describe('SAMLProvider', function() {
 
         const relayState = 'someState'
         const redirectURL = await provider.buildLoginRequestRedirectURL(relayState)
+        const postFormData = await provider.buildLoginRequestPostFormData(relayState)
 
-        await checkRedirectURL(redirectURL, relayState, provider.XSDs.protocol)
+        await checkRedirectURL(redirectURL, relayState, true, provider.XSDs.protocol)
+        await checkPostFormData(postFormData, relayState, true, provider.XSDs.protocol)
     })
 
     it('should generate valid redirect urls for identity provider that use query params ', async function() {
@@ -98,8 +116,10 @@ describe('SAMLProvider', function() {
 
         const relayState = 'someState'
         const redirectURL = await provider.buildLoginRequestRedirectURL(relayState, true)
+        const postFormData = await provider.buildLoginRequestPostFormData(relayState, true)
 
-        await checkRedirectURL(redirectURL, relayState, provider.XSDs.protocol)
+        await checkRedirectURL(redirectURL, relayState, true, provider.XSDs.protocol)
+        await checkPostFormData(postFormData, relayState, true, provider.XSDs.protocol)
     })
 
     it('should generate a valid non-signed login request', async function() {
@@ -107,20 +127,9 @@ describe('SAMLProvider', function() {
 
         const relayState = 'someState'
         const redirectURL = await provider.buildLoginRequestRedirectURL(relayState)
-        const parts = redirectURL.split('?')
+        const postFormData = await provider.buildLoginRequestPostFormData(relayState)
 
-        assert.equal(parts[0], options.idp.redirectLoginUrl, 'Login url must be the one provided in the options')
-
-        const { SAMLRequest, RelayState } = querystring.parse(parts[1])
-
-        assert.equal(RelayState, relayState, 'Relay states do not match')
-        assert.isDefined(SAMLRequest, 'Query should have a SAMLRequest attribute')
-
-        const request = zlib.inflateRawSync(new Buffer(<string>SAMLRequest, 'base64')).toString('utf8')
-
-        // Ths is naive but should be enough for now
-        assert.notInclude(request, 'Signature', 'Request should not signed')
-
-        await provider.XSDs.protocol!(request)
+        await checkRedirectURL(redirectURL, relayState, false, provider.XSDs.protocol)
+        await checkPostFormData(postFormData, relayState, false, provider.XSDs.protocol)
     })
 })

--- a/src/spec/service-provider.ts
+++ b/src/spec/service-provider.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { assert } from 'chai'
-import SAMLProvider from '../service-provider'
+import SAMLProvider, { LoginRequestPostFormData } from '../service-provider'
 import * as querystring from 'querystring'
 import * as zlib from 'zlib'
 import { Validator } from '../helpers/xml'
@@ -68,7 +68,12 @@ describe('SAMLProvider', function() {
         return checkSamlRequest(request, signed, validator)
     }
 
-    function checkPostFormData(data: any, relayState: string, signed: boolean, validator: Validator) {
+    function checkPostFormData(
+        data: LoginRequestPostFormData,
+        relayState: string,
+        signed: boolean,
+        validator: Validator
+    ) {
         assert.equal(data.action, options.idp.redirectLoginUrl)
         assert.equal(data.fields.RelayState, relayState)
 

--- a/src/spec/service-provider.ts
+++ b/src/spec/service-provider.ts
@@ -32,7 +32,8 @@ describe('SAMLProvider', function() {
         },
         idp: {
             id: 'test-idp',
-            loginUrl: 'http://localhost:7000/idp/requestLogin',
+            redirectLoginUrl: 'http://localhost:7000/idp/requestLogin',
+            postLoginUrl: 'http://localhost:7000/idp/requestLogin',
             signature: {
                 certificate: testCert,
                 algorithm: <'sha256'>'sha256',
@@ -44,7 +45,7 @@ describe('SAMLProvider', function() {
 
     function checkRedirectURL(redirectURL: string, relayState: string, validator: Validator) {
         const parts = redirectURL.split('?')
-        assert.equal(parts[0], options.idp.loginUrl, 'Login url must be the one provided in the options')
+        assert.equal(parts[0], options.idp.redirectLoginUrl, 'Login url must be the one provided in the options')
 
         const { SAMLRequest, RelayState } = querystring.parse(parts[1])
 
@@ -77,11 +78,11 @@ describe('SAMLProvider', function() {
     })
 
     it('should generate valid redirect urls for identity provider that use query params ', async function() {
-        const loginUrl = 'http://localhost:7000/idp/requestLogin?param=true'
+        const redirectLoginUrl = 'http://localhost:7000/idp/requestLogin?param=true'
         // Add a parameter to the login url
         const opts = {
             ...options,
-            idp: { ...options.idp, loginUrl }
+            idp: { ...options.idp, redirectLoginUrl }
         }
         const provider = await SAMLProvider.create(opts)
 
@@ -89,7 +90,7 @@ describe('SAMLProvider', function() {
         const redirectURL = await provider.buildLoginRequestRedirectURL(relayState)
 
         // We just make sure that the url is build properly, the other tests will check the data
-        redirectURL.startsWith(loginUrl + '&')
+        redirectURL.startsWith(redirectLoginUrl + '&')
     })
 
     it('should generate a valid signed login request with ForceAuthn set to true', async function() {
@@ -108,7 +109,7 @@ describe('SAMLProvider', function() {
         const redirectURL = await provider.buildLoginRequestRedirectURL(relayState)
         const parts = redirectURL.split('?')
 
-        assert.equal(parts[0], options.idp.loginUrl, 'Login url must be the one provided in the options')
+        assert.equal(parts[0], options.idp.redirectLoginUrl, 'Login url must be the one provided in the options')
 
         const { SAMLRequest, RelayState } = querystring.parse(parts[1])
 

--- a/src/spec/service-provider.ts
+++ b/src/spec/service-provider.ts
@@ -63,7 +63,7 @@ describe('SAMLProvider', function() {
         assert.equal(RelayState, relayState, 'Relay states do not match')
         assert.isDefined(SAMLRequest, 'Query should have a SAMLRequest attribute')
 
-        const request = zlib.inflateRawSync(new Buffer(<string>SAMLRequest, 'base64')).toString('utf8')
+        const request = zlib.inflateRawSync(Buffer.from(<string>SAMLRequest, 'base64')).toString('utf8')
 
         return checkSamlRequest(request, signed, validator)
     }


### PR DESCRIPTION
This will allow arbitrarily large login requests and relay states. Some SSO providers by default have a maximum query string length, which can be exceeded when only allowing HTTP-Redirect.